### PR TITLE
env var added to disable workspace creation for regular users (admin …

### DIFF
--- a/packages/twenty-front/src/modules/client-config/components/ClientConfigProviderEffect.tsx
+++ b/packages/twenty-front/src/modules/client-config/components/ClientConfigProviderEffect.tsx
@@ -20,6 +20,7 @@ import { isImapSmtpCaldavEnabledState } from '@/client-config/states/isImapSmtpC
 import { isMicrosoftCalendarEnabledState } from '@/client-config/states/isMicrosoftCalendarEnabledState';
 import { isMicrosoftMessagingEnabledState } from '@/client-config/states/isMicrosoftMessagingEnabledState';
 import { isMultiWorkspaceEnabledState } from '@/client-config/states/isMultiWorkspaceEnabledState';
+import { isWorkspaceCreationLimitedToAdminsState } from '@/client-config/states/isWorkspaceCreationLimitedToAdminsState';
 import { labPublicFeatureFlagsState } from '@/client-config/states/labPublicFeatureFlagsState';
 import { sentryConfigState } from '@/client-config/states/sentryConfigState';
 import { supportChatState } from '@/client-config/states/supportChatState';
@@ -39,6 +40,9 @@ export const ClientConfigProviderEffect = () => {
   );
   const setIsMultiWorkspaceEnabled = useSetRecoilState(
     isMultiWorkspaceEnabledState,
+  );
+  const setIsWorkspaceCreationLimitedToAdmins = useSetRecoilState(
+    isWorkspaceCreationLimitedToAdminsState,
   );
   const setIsEmailVerificationRequired = useSetRecoilState(
     isEmailVerificationRequiredState,
@@ -148,6 +152,9 @@ export const ClientConfigProviderEffect = () => {
     setIsAnalyticsEnabled(data?.clientConfig.analyticsEnabled);
     setIsDeveloperDefaultSignInPrefilled(data?.clientConfig.signInPrefilled);
     setIsMultiWorkspaceEnabled(data?.clientConfig.isMultiWorkspaceEnabled);
+    setIsWorkspaceCreationLimitedToAdmins(
+      data?.clientConfig.isWorkspaceCreationLimitedToAdmins,
+    );
     setIsEmailVerificationRequired(
       data?.clientConfig.isEmailVerificationRequired,
     );

--- a/packages/twenty-front/src/modules/client-config/states/isWorkspaceCreationLimitedToAdminsState.ts
+++ b/packages/twenty-front/src/modules/client-config/states/isWorkspaceCreationLimitedToAdminsState.ts
@@ -1,0 +1,5 @@
+import { createState } from 'twenty-ui/utilities';
+export const isWorkspaceCreationLimitedToAdminsState = createState<boolean>({
+  key: 'isWorkspaceCreationLimitedToAdmins',
+  defaultValue: false,
+});

--- a/packages/twenty-front/src/modules/client-config/types/ClientConfig.ts
+++ b/packages/twenty-front/src/modules/client-config/types/ClientConfig.ts
@@ -31,6 +31,7 @@ export type ClientConfig = {
   isMicrosoftCalendarEnabled: boolean;
   isMicrosoftMessagingEnabled: boolean;
   isMultiWorkspaceEnabled: boolean;
+  isWorkspaceCreationLimitedToAdmins: boolean;
   isImapSmtpCaldavEnabled: boolean;
   publicFeatureFlags: Array<PublicFeatureFlag>;
   sentry: Sentry;

--- a/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
+++ b/packages/twenty-front/src/modules/ui/navigation/navigation-drawer/components/MultiWorkspaceDropdown/internal/MultiWorkspaceDropdownDefaultComponents.tsx
@@ -2,8 +2,10 @@ import { DEFAULT_WORKSPACE_LOGO } from '@/ui/navigation/navigation-drawer/consta
 
 import { useAuth } from '@/auth/hooks/useAuth';
 import { availableWorkspacesState } from '@/auth/states/availableWorkspacesState';
+import { currentUserState } from '@/auth/states/currentUserState';
 import { currentWorkspaceState } from '@/auth/states/currentWorkspaceState';
 import { countAvailableWorkspaces } from '@/auth/utils/availableWorkspacesUtils';
+import { isWorkspaceCreationLimitedToAdminsState } from '@/client-config/states/isWorkspaceCreationLimitedToAdminsState';
 import { useBuildWorkspaceUrl } from '@/domain-manager/hooks/useBuildWorkspaceUrl';
 import { useRedirectToWorkspaceDomain } from '@/domain-manager/hooks/useRedirectToWorkspaceDomain';
 import { AppPath } from '@/types/AppPath';
@@ -53,6 +55,10 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
   const currentWorkspace = useRecoilValue(currentWorkspaceState);
   const { t } = useLingui();
   const { redirectToWorkspaceDomain } = useRedirectToWorkspaceDomain();
+  const isWorkspaceCreationLimitedToAdmins = useRecoilValue(
+    isWorkspaceCreationLimitedToAdminsState,
+  );
+  const currentUser = useRecoilValue(currentUserState);
   const availableWorkspaces = useRecoilValue(availableWorkspacesState);
   const availableWorkspacesCount =
     countAvailableWorkspaces(availableWorkspaces);
@@ -94,6 +100,9 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
     });
   };
 
+  const workspaceCreationEnabled =
+    !isWorkspaceCreationLimitedToAdmins || currentUser?.canAccessFullAdminPanel;
+
   return (
     <DropdownContent>
       <DropdownMenuHeader
@@ -108,27 +117,29 @@ export const MultiWorkspaceDropdownDefaultComponents = () => {
           />
         }
         EndComponent={
-          <Dropdown
-            clickableComponent={
-              <LightIconButton
-                Icon={IconDotsVertical}
-                size="small"
-                accent="tertiary"
-              />
-            }
-            dropdownId={'multi-workspace-dropdown-context-menu'}
-            dropdownComponents={
-              <DropdownContent>
-                <DropdownMenuItemsContainer>
-                  <MenuItem
-                    LeftIcon={IconPlus}
-                    text={t`Create Workspace`}
-                    onClick={createWorkspace}
-                  />
-                </DropdownMenuItemsContainer>
-              </DropdownContent>
-            }
-          />
+          workspaceCreationEnabled && (
+            <Dropdown
+              clickableComponent={
+                <LightIconButton
+                  Icon={IconDotsVertical}
+                  size="small"
+                  accent="tertiary"
+                />
+              }
+              dropdownId={'multi-workspace-dropdown-context-menu'}
+              dropdownComponents={
+                <DropdownContent>
+                  <DropdownMenuItemsContainer>
+                    <MenuItem
+                      LeftIcon={IconPlus}
+                      text={t`Create Workspace`}
+                      onClick={createWorkspace}
+                    />
+                  </DropdownMenuItemsContainer>
+                </DropdownContent>
+              }
+            />
+          )
         }
       >
         {currentWorkspace?.displayName}

--- a/packages/twenty-front/src/testing/mock-data/config.ts
+++ b/packages/twenty-front/src/testing/mock-data/config.ts
@@ -5,6 +5,7 @@ export const mockedClientConfig: ClientConfig = {
   aiModels: [],
   signInPrefilled: true,
   isMultiWorkspaceEnabled: false,
+  isWorkspaceCreationLimitedToAdmins: false,
   isEmailVerificationRequired: false,
   authProviders: {
     google: true,

--- a/packages/twenty-server/.env.example
+++ b/packages/twenty-server/.env.example
@@ -22,6 +22,7 @@ FRONTEND_URL=http://localhost:3001
 # BILLING_PLAN_REQUIRED_LINK=https://twenty.com/stripe-redirection
 # AUTH_PASSWORD_ENABLED=false
 # IS_MULTIWORKSPACE_ENABLED=false
+# IS_WORKSPACE_CREATION_LIMITED_TO_ADMINS=false
 # AUTH_MICROSOFT_ENABLED=false
 # AUTH_MICROSOFT_CLIENT_ID=replace_me_with_azure_client_id
 # AUTH_MICROSOFT_CLIENT_SECRET=replace_me_with_azure_client_secret

--- a/packages/twenty-server/src/engine/core-modules/auth/auth.module.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/auth.module.ts
@@ -5,8 +5,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { TypeORMModule } from 'src/database/typeorm/typeorm.module';
 import { ApiKey } from 'src/engine/core-modules/api-key/api-key.entity';
+import { ApiKeyService as CoreApiKeyService } from 'src/engine/core-modules/api-key/api-key.service';
 import { AppToken } from 'src/engine/core-modules/app-token/app-token.entity';
 import { AppTokenService } from 'src/engine/core-modules/app-token/services/app-token.service';
+import { ApiAuthController } from 'src/engine/core-modules/auth/controllers/api-auth.controller';
 import { GoogleAPIsAuthController } from 'src/engine/core-modules/auth/controllers/google-apis-auth.controller';
 import { GoogleAuthController } from 'src/engine/core-modules/auth/controllers/google-auth.controller';
 import { MicrosoftAPIsAuthController } from 'src/engine/core-modules/auth/controllers/microsoft-apis-auth.controller';
@@ -115,6 +117,7 @@ import { JwtAuthStrategy } from './strategies/jwt.auth.strategy';
     GoogleAPIsAuthController,
     MicrosoftAPIsAuthController,
     SSOAuthController,
+    ApiAuthController,
   ],
   providers: [
     SignInUpService,
@@ -143,6 +146,7 @@ import { JwtAuthStrategy } from './strategies/jwt.auth.strategy';
     UpdateConnectedAccountOnReconnectService,
     TransientTokenService,
     ApiKeyService,
+    CoreApiKeyService,
     AuthSsoService,
   ],
   exports: [AccessTokenService, LoginTokenService, RefreshTokenService],

--- a/packages/twenty-server/src/engine/core-modules/auth/controllers/api-auth.controller.ts
+++ b/packages/twenty-server/src/engine/core-modules/auth/controllers/api-auth.controller.ts
@@ -1,0 +1,56 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+
+import { ApiKeyService } from 'src/engine/core-modules/api-key/api-key.service';
+import { CreateUserAndWorkspaceInput } from 'src/engine/core-modules/auth/dto/create-user-and-workspace.input';
+import { SignInUpService } from 'src/engine/core-modules/auth/services/sign-in-up.service';
+import { DomainManagerService } from 'src/engine/core-modules/domain-manager/services/domain-manager.service';
+import { WorkspaceService } from 'src/engine/core-modules/workspace/services/workspace.service';
+import { ApiKeyGuard } from 'src/engine/guards/api-key-guard';
+
+@Controller('auth/api')
+@UseGuards(ApiKeyGuard)
+export class ApiAuthController {
+  constructor(
+    private readonly signInUpService: SignInUpService,
+    private readonly domainManagerService: DomainManagerService,
+    private readonly apiKeyService: ApiKeyService,
+    private readonly workspaceService: WorkspaceService,
+  ) {}
+
+  @Post('create-user-and-workspace')
+  async createUserAndWorkspace(@Body() userData: CreateUserAndWorkspaceInput) {
+    const { user, workspace } = await this.signInUpService.signUpOnNewWorkspace(
+      {
+        type: 'newUserWithPicture',
+        newUserWithPicture: userData,
+      },
+    );
+
+    await this.workspaceService.activateWorkspace(user, workspace, {
+      displayName: workspace.subdomain,
+    });
+
+    // Create an API key for the workspace, valid for 5 year
+    const oneYearMs = 5 * 365 * 24 * 60 * 60 * 1000;
+    const expiresAt = new Date(Date.now() + oneYearMs);
+
+    const apiKey = await this.apiKeyService.create({
+      name: 'Webapp',
+      workspaceId: workspace.id,
+      expiresAt,
+    });
+
+    const apiToken = await this.apiKeyService.generateApiKeyToken(
+      workspace.id,
+      apiKey.id,
+    );
+
+    return {
+      userId: user.id,
+      workspaceId: workspace.id,
+      workspaceUrls: this.domainManagerService.getWorkspaceUrls(workspace),
+      apiToken: apiToken?.token,
+      expiresAt,
+    };
+  }
+}

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.controller.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.controller.spec.ts
@@ -66,6 +66,7 @@ describe('ClientConfigController', () => {
         },
         signInPrefilled: false,
         isMultiWorkspaceEnabled: true,
+        isWorkspaceCreationLimitedToAdmins: false,
         isEmailVerificationRequired: false,
         defaultSubdomain: 'app',
         frontDomain: 'localhost',

--- a/packages/twenty-server/src/engine/core-modules/client-config/client-config.entity.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/client-config.entity.ts
@@ -127,6 +127,9 @@ export class ClientConfig {
   isMultiWorkspaceEnabled: boolean;
 
   @Field(() => Boolean)
+  isWorkspaceCreationLimitedToAdmins: boolean;
+
+  @Field(() => Boolean)
   isEmailVerificationRequired: boolean;
 
   @Field(() => String, { nullable: true })

--- a/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.spec.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.spec.ts
@@ -66,6 +66,7 @@ describe('ClientConfigService', () => {
             AUTH_MICROSOFT_ENABLED: false,
             SIGN_IN_PREFILLED: false,
             IS_MULTIWORKSPACE_ENABLED: true,
+            IS_WORKSPACE_CREATION_LIMITED_TO_ADMINS: false,
             IS_EMAIL_VERIFICATION_REQUIRED: true,
             DEFAULT_SUBDOMAIN: 'app',
             NODE_ENV: NodeEnvironment.DEVELOPMENT,

--- a/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.ts
+++ b/packages/twenty-server/src/engine/core-modules/client-config/services/client-config.service.ts
@@ -97,6 +97,9 @@ export class ClientConfigService {
       isMultiWorkspaceEnabled: this.twentyConfigService.get(
         'IS_MULTIWORKSPACE_ENABLED',
       ),
+      isWorkspaceCreationLimitedToAdmins: this.twentyConfigService.get(
+        'IS_WORKSPACE_CREATION_LIMITED_TO_ADMINS',
+      ),
       isEmailVerificationRequired: this.twentyConfigService.get(
         'IS_EMAIL_VERIFICATION_REQUIRED',
       ),

--- a/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
+++ b/packages/twenty-server/src/engine/core-modules/twenty-config/config-variables.ts
@@ -1048,6 +1048,15 @@ export class ConfigVariables {
   IS_MULTIWORKSPACE_ENABLED = false;
 
   @ConfigVariablesMetadata({
+    group: ConfigVariablesGroup.ServerConfig,
+    description: 'Enable or disable workspace creation by users',
+    type: ConfigVariableType.BOOLEAN,
+    isEnvOnly: true,
+  })
+  @IsOptional()
+  IS_WORKSPACE_CREATION_LIMITED_TO_ADMINS = false;
+
+  @ConfigVariablesMetadata({
     group: ConfigVariablesGroup.Other,
     description:
       'Number of inactive days before sending a deletion warning for workspaces. Used in the workspace deletion cron job to determine when to send warning emails.',

--- a/packages/twenty-server/src/engine/guards/api-key-guard.ts
+++ b/packages/twenty-server/src/engine/guards/api-key-guard.ts
@@ -1,0 +1,19 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const apiKey = request.headers['x-api-key'];
+
+    if (apiKey && apiKey === process.env.API_KEY) {
+      return true;
+    }
+    throw new UnauthorizedException('Invalid API key');
+  }
+}

--- a/tools/eslint-rules/rules/rest-api-methods-should-be-guarded.spec.ts
+++ b/tools/eslint-rules/rules/rest-api-methods-should-be-guarded.spec.ts
@@ -39,6 +39,15 @@ ruleTester.run(RULE_NAME, rule, {
       code: `
         class TestController {
           @Get()
+          @UseGuards(ApiKeyGuard)
+          testMethod() {}
+        }
+      `,
+    },
+    {
+      code: `
+        class TestController {
+          @Get()
           @UseGuards(CaptchaGuard, PublicEndpoint)
           testMethod() {}
         }
@@ -65,6 +74,15 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: `
         @UseGuards(PublicEndpoint)
+        class TestController {
+          @Get()
+          testMethod() {}
+        }
+      `,
+    },
+    {
+      code: `
+        @UseGuards(ApiKeyGuard)
         class TestController {
           @Get()
           testMethod() {}

--- a/tools/eslint-rules/utils/typedTokenHelpers.ts
+++ b/tools/eslint-rules/utils/typedTokenHelpers.ts
@@ -44,7 +44,8 @@ export const typedTokenHelpers = {
           if (arg.type === TSESTree.AST_NODE_TYPES.Identifier) {
             return arg.name === 'UserAuthGuard' || 
                    arg.name === 'WorkspaceAuthGuard' || 
-                   arg.name === 'PublicEndpointGuard';
+                   arg.name === 'PublicEndpointGuard' ||
+                   arg.name === 'ApiKeyGuard';
           }
           return false;
         });


### PR DESCRIPTION
…panel level only). also added an api-auth.controller to allow an external service to create a user, activate a workspace and create a workspace api key.

These changes will most likely not make it back upstream as they are too specific a use case. We'll re-evaluate down the road if an alternative approach is introduced upstream.